### PR TITLE
Update test.pypi.org bug fix

### DIFF
--- a/update.sh
+++ b/update.sh
@@ -26,7 +26,7 @@ fi
 #release new version on test.pypi, then install on local
 if [ $WHERE = "test" ]; then
   printf "Uploading '$PKG_NAME' to https://test.pypi.org/project/$PKG_NAME/.\n"
-  twine upload -q --repository-url https://test.pypi.org/legacy/ dist/*
+  twine upload --repository-url https://test.pypi.org/legacy/ dist/*
   sleep 3
   printf "Installing and updating '$PKG_NAME' with pip.\n"
   pip3 install -q --no-cache-dir --upgrade --index-url https://test.pypi.org/simple "$PKG_NAME"

--- a/update.sh
+++ b/update.sh
@@ -39,6 +39,9 @@ if [ $WHERE = "prod" ]; then
   sleep 3
   printf "Installing and updating '$PKG_NAME' with pip.\n"
   pip3 install --no-cache-dir --upgrade "$PKG_NAME"
+  #retroactively release on test.pypi as well
+  printf "Uploading '$PKG_NAME' to https://test.pypi.org/project/$PKG_NAME/.\n"
+  twine upload --repository-url https://test.pypi.org/legacy/ dist/*
 fi
 
 #cleanup build files

--- a/update.sh
+++ b/update.sh
@@ -29,7 +29,7 @@ if [ $WHERE = "test" ]; then
   twine upload --repository-url https://test.pypi.org/legacy/ dist/*
   sleep 3
   printf "Installing and updating '$PKG_NAME' with pip.\n"
-  pip3 install -q --no-cache-dir --upgrade --index-url https://test.pypi.org/simple "$PKG_NAME"
+  pip3 install --no-cache-dir --upgrade --index-url https://test.pypi.org/simple "$PKG_NAME"
 fi
 
 #release new version on real pypi, then install on local


### PR DESCRIPTION
Removed -q flag from twine command; twine does not support suppressed output. Also made 'update.sh <proj> prod' retroactively update test.pypi when finished.