### PR TITLE
fixed python version in setup.py

### DIFF
--- a/pipgen/pipgen/pipify.sh
+++ b/pipgen/pipgen/pipify.sh
@@ -85,7 +85,8 @@ fi
 
 #generate setup.py template
 printf "Creating setup.py from project dependencies.\n"
-PYTHON_VERSION=$(python3 --version | sed -E 's/[Pp]ython //')
+PYTHON_VERSION=$(python3 --version | sed -E 's/Python //')
+PYTHON_VERSION=${PYTHON_VERSION:0:1}
 cat > setup.py <<- EOM
 import setuptools
 


### PR DESCRIPTION
Added a small bug fix where PyPi didn't like the full Python version. When Python updated to 3.7.4, PyPi threw an error saying "invalid version of Python." The workaround is to simply echo "3" instead of the full version.