### PR TITLE
only make __init__.py if .py files exist

### DIFF
--- a/pipgen/bin/depipify.sh
+++ b/pipgen/bin/depipify.sh
@@ -16,6 +16,6 @@ rm requirements.txt
 for DIR in ./*/ ./*/**/; do
   rm "$DIR"/__init__.py 2>/dev/null || true
 done
-mv "$PKG_NAME"/* bin/* . 2>/dev/null || true
+mv */* . 2>/dev/null || true
 rm setup.py
-rm -rf "$PKG_NAME" bin/ 2>/dev/null || true
+rm -rf */ 2>/dev/null || true

--- a/pipgen/bin/pipify.sh
+++ b/pipgen/bin/pipify.sh
@@ -42,7 +42,10 @@ else
   fi
 fi
 for DIR in $SEARCHTREE; do
-  echo "$(ls -1 "$DIR" | grep .py | sed -E 's/^/from \./g' | sed -E 's/.py//g' | sed -E 's/$/ import */g')" > ./"$DIR"/__init__.py
+  NUMPYFILES=$(ls -1 $DIR | grep '.py'| wc -l | sed -E 's/[[:blank:]]//g')
+  if [ $NUMPYFILES != "0" ]; then
+    echo "$(ls -1 "$DIR" | grep .py | sed -E 's/^/from \./g' | sed -E 's/.py//g' | sed -E 's/$/ import */g')" > ./"$DIR"/__init__.py
+  fi
 done
 #move extensionless script files to /bin
 INCLUDESCRIPTS="$(ls -F | grep -v '/' | grep -v '\.' | grep -v 'LICENSE') $(ls | grep '.sh')"

--- a/pipgen/setup.py
+++ b/pipgen/setup.py
@@ -5,7 +5,7 @@ with open("README.md", "r") as fh:
 
 setuptools.setup(
   name = "pipgen",
-  version = "0.0.4",
+  version = "0.0.5",
   author = "Casey Johnson",
   author_email = "ctj0001@mix.wvu.edu",
   description = "A package for easily creating and distributing pip packages.",


### PR DESCRIPTION
# Merge `subfolderbug` into `master`

This PR fixes two bugs:

**BUG 1:**
`pipgen.depipify()` sometimes deletes source from subfolders in renamed projects.

**STEPS TO RECREATE:**
1. Copy a pip-compliant project (eg, the pipgen source) to a new folder.
2. Rename the copy's root folder.
3. Run `pipgen.depipify()` on the new copy.

**BUG 2:**
`pipgen.pipify()` creates `__init__.py` in folders containing non-Python files.

**STEPS TO RECREATE:**
1. Add an empty folder to a Python project.
2. Run `pipgen.pipify()` on the project.