### PR TITLE
undo bug 'fix'

### DIFF
--- a/pipgen/bin/depipify.sh
+++ b/pipgen/bin/depipify.sh
@@ -18,4 +18,4 @@ for DIR in ./*/ ./*/**/; do
 done
 mv */* . 2>/dev/null || true
 rm setup.py
-rm -rf */ 2>/dev/null || true
+rm -rf "$PKG_NAME" 2>/dev/null || true

--- a/pipgen/setup.py
+++ b/pipgen/setup.py
@@ -5,7 +5,7 @@ with open("README.md", "r") as fh:
 
 setuptools.setup(
   name = "pipgen",
-  version = "0.0.5",
+  version = "0.0.6",
   author = "Casey Johnson",
   author_email = "ctj0001@mix.wvu.edu",
   description = "A package for easily creating and distributing pip packages.",


### PR DESCRIPTION
This PR reverts a 'fix' from Bug 1 in PR #11. In the bug, running `pipgen.depipify()` on a renamed project did not correctly depipify the project source. This issue is rare, though, and attempting to fix it caused subfolders in pip-compliant project trees to be deleted entirely.

Just don't rename a project. Or, depipify a project, rename it, and re-pipify it.