### PR TITLE
dependencies managed by pipgen installation

### DIFF
--- a/pipgen/bin/pipify.sh
+++ b/pipgen/bin/pipify.sh
@@ -117,8 +117,4 @@ setuptools.setup(
 )
 EOM
 
-#create a file for pip3 requirements
-printf "Creating package requirements.txt.\n"
-echo "twine\nsetuptools\nwheel" > requirements.txt
-
 printf "\nPip package '$PKG_NAME' successfully created.\n\n"

--- a/pipgen/requirements.txt
+++ b/pipgen/requirements.txt
@@ -1,3 +1,0 @@
-twine
-setuptools
-wheel

--- a/pipgen/setup.py
+++ b/pipgen/setup.py
@@ -5,7 +5,7 @@ with open("../README.md") as readmefile:
 
 setuptools.setup(
   name = "pipgen",
-  version = "0.2.0",
+  version = "0.2.1",
   author = "Casey Johnson",
   author_email = "ctj0001@mix.wvu.edu",
   description = "A package for easily creating and distributing pip packages.",
@@ -15,7 +15,7 @@ setuptools.setup(
   packages = setuptools.find_packages(),
   include_package_data = True,
   scripts = ['./bin/pipify.sh', './bin/depipify.sh', './bin/pippush.sh'],
-  install_requires = [],
+  install_requires = ['twine', 'setuptools', 'wheel'],
   classifiers = [
     "Programming Language :: Python :: 3",
     "License :: OSI Approved :: MIT License",


### PR DESCRIPTION
Previously, the pip dependencies twine, setuptools, and wheel have been installed and updated every time they're needed. With this PR, they're installed only when pipgen itself is installed.